### PR TITLE
Update to work modern versions of Poetry

### DIFF
--- a/poetry2setup.py
+++ b/poetry2setup.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
-from poetry.core.utils._compat import Path
+from pathlib import Path
+
 from poetry.core.factory import Factory
 from poetry.core.masonry.builders.sdist import SdistBuilder
 


### PR DESCRIPTION
Poetry core's version of _compat has not had Path support since November of 2021, so since Poetry has dropped support for all versions of python prior to 3.5, it makes sense to do the same here (especially since it breaks on install as it is.)

Commit where the Path compatibility layer was removed: https://github.com/python-poetry/poetry-core/commit/b103125e4591a0c78361b0626880dbcf1dcb61e6#diff-2f5b1e2f4018ccd3676ad249cf3bd9f9c24e657053b12ea7281c08f821cc717bL41-L44